### PR TITLE
Read $HOME/.vimrc.local if it exists

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -306,3 +306,6 @@ autocmd BufReadPost fugitive://*
   \   nnoremap <buffer> .. :edit %:h<CR> |
   \ endif
 
+if filereadable(expand("$HOME/.vimrc.local"))
+    source $HOME/.vimrc.local
+endif


### PR DESCRIPTION
This simple feature makes it possible to keep local host specific config in $HOME/.vimrc.local
